### PR TITLE
Downloading Common Ancestor, Fixing directory structure

### DIFF
--- a/SemDiff.Core/GitHub.cs
+++ b/SemDiff.Core/GitHub.cs
@@ -34,6 +34,7 @@ namespace SemDiff.Core
             };
             Client.DefaultRequestHeaders.UserAgent.ParseAdd(nameof(SemDiff));
             Client.DefaultRequestHeaders.Accept.ParseAdd("application/vnd.github.v3+json");
+            RepoFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), nameof(SemDiff), RepoOwner, RepoName);
         }
 
         public GitHub(string repoOwner, string repoName, string authUsername, string authToken) : this(repoOwner, repoName)
@@ -49,6 +50,7 @@ namespace SemDiff.Core
         public string RepoOwner { get; set; }
         public int RequestsRemaining { get; private set; }
         public HttpClient Client { get; private set; }
+        public string RepoFolder { get; set; }
 
         private async void APIError(string content)
         {
@@ -126,8 +128,7 @@ namespace SemDiff.Core
         {
             var rawText = await HttpGetAsync($@"https://github.com/{RepoOwner}/{RepoName}/raw/{sha}/{path}");
             path = path.Replace('/', Path.DirectorySeparatorChar);
-            var dir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), nameof(SemDiff));
-            dir = Path.Combine(dir, $"{prNum}", path);
+            var dir = Path.Combine(RepoFolder, $"{prNum}", path);
 
             if (isAncestor)
             {

--- a/SemDiff.Test/PullRequestListTest.cs
+++ b/SemDiff.Test/PullRequestListTest.cs
@@ -78,7 +78,7 @@ namespace SemDiff.Test
                         foreach (var f in r.Files)
                         {
                             directoryTokens = f.Filename.Split('/');
-                            dir = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + "/SemDiff/";
+                            dir = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + "/SemDiff/semdiffdotnet/curly-broccoli/";
 
                             dir = Path.Combine(dir, r.Number.ToString(), f.Filename);
                         }

--- a/SemDiff.Test/PullRequestListTest.cs
+++ b/SemDiff.Test/PullRequestListTest.cs
@@ -2,59 +2,64 @@
 using SemDiff.Core;
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 
 namespace SemDiff.Test
 {
     [TestClass]
     public class PullRequestListTest
     {
-        string owner = "semdiffdotnet";
-        string repository = "curly-broccoli";
-        GitHub github;
+        private const string owner = "semdiffdotnet";
+        private const string repository = "curly-broccoli";
+        public static GitHub github;
 
-        public void setGitHub()
+        [TestInitialize]
+        public void TestInit()
         {
             github = new GitHub(owner, repository);
+            var appDataFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), nameof(SemDiff));
+            if (new FileInfo(appDataFolder).Exists)
+                Directory.Delete(appDataFolder, recursive: true);
         }
+
         [TestMethod]
         public void NewGitHub()
         {
-            setGitHub();
             Assert.AreEqual(github.RepoName, repository);
             Assert.AreEqual(github.RepoOwner, owner);
-
         }
+
         [TestMethod]
         public void PullRequestFromTestRepo()
         {
-            setGitHub();
             var requests = github.GetPullRequests();
-            var fourWasFound = false;
             if (github.RequestsRemaining != 0)
             {
-                foreach(var r in requests)
+                Assert.AreEqual(4, requests.Count);
+                var r = requests.First();
+                if (r.Number == 4)
                 {
-                   if(r.number == 4)
+                    Assert.AreEqual(r.Locked, false);
+                    Assert.AreEqual(r.State, "open");
+                    Assert.AreEqual(r.User.Login, "haroldhues");
+                    Assert.AreEqual(r.Files.Count, 1);
+                    foreach (var f in r.Files)
                     {
-                        fourWasFound = true;
-                        Assert.AreEqual(r.locked,false);
-                        Assert.AreEqual(r.state, "open");
-                        Assert.AreEqual(r.user.login, "haroldhues");
-                        Assert.AreEqual(r.files.Count, 1);
-                        foreach(var f in r.files)
-                        {
-                            Assert.AreEqual(f.filename, "Curly-Broccoli/Curly/Logger.cs");
-                            Assert.AreEqual(f.raw_url, "https://github.com/semdiffdotnet/curly-broccoli/raw/895d2ca038344aacfbcf3902e978de73a7a763fe/Curly-Broccoli/Curly/Logger.cs");
-                        }
+                        Assert.AreEqual("Curly-Broccoli/Curly/Logger.cs", f.Filename);
                     }
                 }
-                Assert.AreEqual(fourWasFound, true);
+                else
+                {
+                    Assert.Fail();
+                }
+                Assert.AreEqual("895d2ca038344aacfbcf3902e978de73a7a763fe", r.Head.Sha);
             }
         }
+
         [TestMethod]
         public void GetFilesFromGitHub()
         {
-            setGitHub();
             var requests = github.GetPullRequests();
             var fourWasFound = false;
             if (github.RequestsRemaining != 0)
@@ -62,29 +67,20 @@ namespace SemDiff.Test
                 Assert.AreNotEqual(github.RequestsRemaining, 0);
                 foreach (var r in requests)
                 {
-                    github.DownloadFiles(r);
-                    if (r.number == 4)
+                    github.DownloadFiles(r).Wait();
+                    if (r.Number == 4)
                     {
                         fourWasFound = true;
                         string line;
                         int counter = 0;
                         string[] directoryTokens;
                         string dir = "";
-                        foreach (var f in r.files)
+                        foreach (var f in r.Files)
                         {
-                            directoryTokens = f.filename.Split('/');
+                            directoryTokens = f.Filename.Split('/');
                             dir = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + "/SemDiff/";
-                            foreach (var token in directoryTokens)
-                            {
-                                if (token != directoryTokens[0])
-                                {
-                                    dir = dir + "/" + token;
-                                }
-                                else
-                                {
-                                    dir = dir + token + "/" + r.number;
-                                }
-                            }
+
+                            dir = Path.Combine(dir, r.Number.ToString(), f.Filename);
                         }
                         using (var file = new System.IO.StreamReader(dir))
                         {

--- a/SemDiff.Test/PullRequestListTest.cs
+++ b/SemDiff.Test/PullRequestListTest.cs
@@ -67,7 +67,7 @@ namespace SemDiff.Test
                 Assert.AreNotEqual(github.RequestsRemaining, 0);
                 foreach (var r in requests)
                 {
-                    github.DownloadFiles(r).Wait();
+                    github.DownloadFiles(r);
                     if (r.Number == 4)
                     {
                         fourWasFound = true;


### PR DESCRIPTION
Common ancestor (the file base) is downloaded and stored alongside the changed file (the head file) with an `.orig` extension.

While I was working on that I discovered that the directory structure was kind of messed up.

The file `Curly-Broccoli/Curly/Logger.cs` was being stored in `AppData\Roaming\SemDiff\Curly-Broccoli\04\Curly\Logger.cs` when it should have been stored as `AppData\Roaming\SemDiff\04\Curly-Broccoli\Curly\Logger.cs`. This was probably do to the fact that the first dir is the name of the repo, which was confusing.

While I was there, I added `{RepoOwner}\{RepoName}` directories before the pull number to avoid possible collisions