### PR TITLE
Add missing enum member that rarely appears in github api

### DIFF
--- a/SemDiff.Core/GitHub.cs
+++ b/SemDiff.Core/GitHub.cs
@@ -200,6 +200,10 @@ namespace SemDiff.Core
                         case Files.StatusEnum.Renamed: //Not sure how to handle this one...
                             break;
 
+                        case Files.StatusEnum.Changed:
+                            Logger.Info($"The mythical 'changed' status has occured! {pr.Number}:{current.Filename}");
+                            goto case Files.StatusEnum.Modified; //Effectivly falls through to the following
+
                         case Files.StatusEnum.Modified:
                             var headTsk = DownloadFileAsync(pr.Number, current.Filename, pr.Head.Sha);
                             var ancTsk = DownloadFileAsync(pr.Number, current.Filename, pr.Base.Sha, isAncestor: true);
@@ -269,7 +273,11 @@ namespace SemDiff.Core
                     Date = Updated,
                     Title = Title,
                     Url = Url,
-                    Files = Files.Where(f => f.Status == GitHub.Files.StatusEnum.Modified).Where(f => f.Filename.Split('.').Last() == "cs").Select(f => f.ToRemoteFile(repofolder, Number)).ToList(),
+                    Files = Files
+                        .Where(f => f.Status == GitHub.Files.StatusEnum.Modified || f.Status == GitHub.Files.StatusEnum.Changed)
+                        .Where(f => f.Filename.Split('.').Last() == "cs")
+                        .Select(f => f.ToRemoteFile(repofolder, Number))
+                        .ToList(),
                 };
             }
         }
@@ -300,7 +308,12 @@ namespace SemDiff.Core
                 Added,
                 Modified,
                 Removed,
-                Renamed
+                Renamed,
+
+                //Mostly undocumented, occurs rarely
+                //Seems to show up when only the file permissions were changed
+                //or if there are too many files it the pull request (more than about 200)
+                Changed
             }
         }
 


### PR DESCRIPTION
When requesting `api.github.com/repositories/29078997/pulls/9527/files?page=7` this field was discovered and caused errors.