### PR TITLE
Code Clean-Up - Update Documentation and Format Code

### DIFF
--- a/SemDiff.Core/Analysis.cs
+++ b/SemDiff.Core/Analysis.cs
@@ -1,9 +1,7 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -18,9 +16,14 @@ namespace SemDiff.Core
         /// <summary>
         /// Given a Repo and a Tree find any possible FalsePositives
         /// </summary>
-        public static IEnumerable<DetectedFalsePositive> ForFalsePositive(Repo repo, SyntaxTree tree, string filePath)
+        /// <param name="repo">Repo that has the remote changes that need to be checked</param>
+        /// <param name="tree">The syntax tree that will be compared with syntax trees from repo</param>
+        /// <param name="filePath">The path that the syntax tree was parsed from</param>
+        public static IEnumerable<DetectedFalsePositive> ForFalsePositive(Repo repo,
+            SyntaxTree tree, string filePath) //TODO: Remove filePath, retrieve from SyntaxTree instead
         {
-            var relativePath = GetRelativePath(repo.LocalDirectory, filePath).Replace('\\', '/'); //Standardize Directory Separator!
+            var relativePath = GetRelativePath(repo.LocalDirectory, filePath)
+                                        .Replace('\\', '/'); //Standardize Directory Separator!
             if (string.IsNullOrWhiteSpace(relativePath))
             {
                 yield break;
@@ -34,7 +37,8 @@ namespace SemDiff.Core
                 var conflicts = Diff3.Compare(f.Base, tree, f.File);
                 var locs = GetInsertedMethods(conflicts.Local);
                 var rems = GetInsertedMethods(conflicts.Remote);
-                foreach (var c in conflicts.Conflicts.Where(con => con.Ancestor.Node is MethodDeclarationSyntax)) //Warning: do we need to convert Conflicts to list first?
+                foreach (var c in conflicts.Conflicts //TODO: do we need to convert Conflicts to list first?
+                                .Where(con => con.Ancestor.Node is MethodDeclarationSyntax))
                 {
                     var ancestor = (MethodDeclarationSyntax)c.Ancestor.Node;
                     if (ancestor == null)
@@ -45,12 +49,15 @@ namespace SemDiff.Core
                     {
                         var diff3 = t.Item3;
                         var local = t.Item2; //local removed
-                        if (!diff3.Conflicts.Any()) //TODO: this doesn't filter out things like adding comments yet
+                        if (!diff3.Conflicts.Any()) //TODO: this doesn't filter out adding comments yet
                         {
                             //Since Inner method actually has no conflicts, we found a false positive
                             yield return new DetectedFalsePositive
                             {
-                                Location = Location.Create(tree, local.Span), //TODO: how does one Figure out the affected region? This is difficult because it is different for if the local file removed the method or changed it!
+                                //TODO: how does one Figure out the affected region? This is difficult
+                                // because it is different for if the local file removed the method or
+                                // changed it!
+                                Location = Location.Create(tree, local.Span),
                                 RemoteFile = f,
                                 RemoteChange = p,
                                 ConflictType = DetectedFalsePositive.ConflictTypes.LocalMethodRemoved,
@@ -61,13 +68,14 @@ namespace SemDiff.Core
                     foreach (var t in remoteRemoved)
                     {
                         var diff3 = t.Item3;
-                        var local = t.Item1; //If the remote was removed then that means that the local was changed
-                        if (!diff3.Conflicts.Any()) //TODO: this doesn't filter out things like adding comments yet
+                        var local = t.Item1; //If the remote was removed then the local was changed
+                        if (!diff3.Conflicts.Any()) //TODO: filter
                         {
                             //Since Inner method actually has no conflicts, we found a false positive
                             yield return new DetectedFalsePositive
                             {
-                                Location = Location.Create(tree, local.Span), //TODO: how does one Figure out the affected region? This is difficult because it is different for if the local file removed the method or changed it!
+                                //TODO: return more accurate location
+                                Location = Location.Create(tree, local.Span),
                                 RemoteFile = f,
                                 RemoteChange = p,
                                 ConflictType = DetectedFalsePositive.ConflictTypes.LocalMethodChanged,
@@ -78,57 +86,47 @@ namespace SemDiff.Core
             }
         }
 
-        //Tuple is Changed, Removed, and the diff result
-        private static IEnumerable<Tuple<MethodDeclarationSyntax, MethodDeclarationSyntax, Diff3Result>> GetInnerMethodConflicts(MethodDeclarationSyntax ancestor, SpanDetails changed, SpanDetails removed, List<MethodDeclarationSyntax> insertedMethods)
-        {
-            if (string.IsNullOrWhiteSpace(removed.Text))
-            {
-                var change = changed.Node as MethodDeclarationSyntax;
-                if (change != null)
-                {
-                    var methodName = change.Identifier.Text;
-                    foreach (var moved in insertedMethods.Where(method => method.Identifier.Text == methodName))
-                    {
-                        var diffRes = Diff3.Compare(ancestor, moved, change);
-                        if (!diffRes.Conflicts.Any())
-                        {
-                            yield return Tuple.Create(change, moved, diffRes);
-                        }
-                    }
-                }
-            }
-        }
-
-        //A move looks like a deleted method and then an added method in another place, this find the added methods
-        private static List<MethodDeclarationSyntax> GetInsertedMethods(List<Diff> diffs)
-        {
-            return diffs
-                     .Where(diff => string.IsNullOrWhiteSpace(diff.Ancestor.Text))
-                     .Select(diff => diff.Changed.Node as MethodDeclarationSyntax)
-                     .Where(node => node != null).ToList();
-        }
-
         /// <summary>
         /// Given a Repo and a Semantic Model find any possible FalseNegatives
         /// </summary>
-        public static IEnumerable<DetectedFalseNegative> ForFalseNegative(Repo repo, SemanticModel semanticModel)
+        /// <param name="repo">Repo that has the remote changes that need to be checked</param>
+        /// <param name="semanticModel">the semantic model that will be used to find the base class</param>
+        public static IEnumerable<DetectedFalseNegative> ForFalseNegative(Repo repo,
+                                                                        SemanticModel semanticModel)
         {
-            var classDeclarations = semanticModel.SyntaxTree.GetRoot().DescendantNodes().OfType<ClassDeclarationSyntax>();
+            var classDeclarations = semanticModel.SyntaxTree
+                                        .GetRoot()
+                                        .DescendantNodes()
+                                        .OfType<ClassDeclarationSyntax>();
+
             var declaredSymbol = classDeclarations.Select(cds => semanticModel.GetDeclaredSymbol(cds));
+
             var classBases = declaredSymbol.SelectMany(
-                    t => (t as INamedTypeSymbol)?.BaseType?.DeclaringSyntaxReferences ?? Enumerable.Empty<SyntaxReference>()
-                );
-            var classBaseNodes = Task.WhenAll(classBases.Select(sr => sr.GetSyntaxAsync())).Result.OfType<ClassDeclarationSyntax>();
+                    t => (t as INamedTypeSymbol)?.BaseType
+                                    ?.DeclaringSyntaxReferences ?? Enumerable.Empty<SyntaxReference>());
+
+            var classBaseNodes = Task.WhenAll(classBases.Select(sr => sr.GetSyntaxAsync()))
+                                                            .Result.OfType<ClassDeclarationSyntax>();
+
             return classBaseNodes.SelectMany(c =>
             {
-                var relativePath = GetRelativePath(repo.LocalDirectory, c.SyntaxTree.FilePath).Replace('\\', '/'); //Standardize Directory Separator!
+                var relativePath = GetRelativePath(repo.LocalDirectory, c.SyntaxTree.FilePath)
+                                            .Replace('\\', '/'); //Standardize Directory Separator!
+
                 return GetPulls(repo, relativePath).SelectMany(t =>
                 {
                     var file = t.Item1;
                     var remotechanges = t.Item2;
 
-                    var ancestorDecs = file.Base.GetRoot().DescendantNodes().OfType<ClassDeclarationSyntax>();
-                    var remoteDecs = file.File.GetRoot().DescendantNodes().OfType<ClassDeclarationSyntax>();
+                    var ancestorDecs = file.Base
+                                            .GetRoot()
+                                            .DescendantNodes()
+                                            .OfType<ClassDeclarationSyntax>();
+
+                    var remoteDecs = file.File
+                                            .GetRoot()
+                                            .DescendantNodes()
+                                            .OfType<ClassDeclarationSyntax>();
 
                     return MergeClassDeclarationSyntaxes(ancestorDecs, remoteDecs)
                             .Select(ar => Diff3.Compare(ar.Item1, c, ar.Item2))
@@ -144,7 +142,72 @@ namespace SemDiff.Core
             });
         }
 
-        private static IEnumerable<Tuple<ClassDeclarationSyntax, ClassDeclarationSyntax>> MergeClassDeclarationSyntaxes(IEnumerable<ClassDeclarationSyntax> left, IEnumerable<ClassDeclarationSyntax> rightE)
+        internal static IEnumerable<Tuple<RemoteFile, RemoteChanges>> GetPulls(Repo repo,
+                                                                            string relativePath)
+        {
+            return repo.RemoteChangesData
+                .Select(kvp => kvp.Value)
+                .SelectMany(p => p.Files
+                                   .Select(f => new { n = f.Filename, f, p }))
+                                   .Where(a => a.n == relativePath)
+                                   .Select(a => Tuple.Create(a.f, a.p))
+                .ToList();
+        }
+
+        internal static string GetRelativePath(string localDirectory, string filePath)
+        {
+            var local = Path.GetFullPath(localDirectory);
+            var file = Path.GetFullPath(filePath);
+            if (file.StartsWith(local))
+            {
+                var relative = file.Substring(local.Length);
+                return relative.StartsWith(Path.DirectorySeparatorChar.ToString())
+                    ? relative.Substring(1)
+                    : relative;
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        //Tuple is Changed, Removed, and the diff result
+        private static IEnumerable<Tuple<MethodDeclarationSyntax, MethodDeclarationSyntax, Diff3Result>>
+            GetInnerMethodConflicts(MethodDeclarationSyntax ancestor, SpanDetails changed,
+            SpanDetails removed, List<MethodDeclarationSyntax> insertedMethods)
+        {
+            if (string.IsNullOrWhiteSpace(removed.Text))
+            {
+                var change = changed.Node as MethodDeclarationSyntax;
+                if (change != null)
+                {
+                    var methodName = change.Identifier.Text;
+                    foreach (var moved in insertedMethods
+                        .Where(method => method.Identifier.Text == methodName))
+                    {
+                        var diffRes = Diff3.Compare(ancestor, moved, change);
+                        if (!diffRes.Conflicts.Any())
+                        {
+                            yield return Tuple.Create(change, moved, diffRes);
+                        }
+                    }
+                }
+            }
+        }
+
+        //A move looks like a deleted method and then an added method in
+        // another place, this find the added methods
+        private static List<MethodDeclarationSyntax> GetInsertedMethods(List<Diff> diffs)
+        {
+            return diffs
+                     .Where(diff => string.IsNullOrWhiteSpace(diff.Ancestor.Text))
+                     .Select(diff => diff.Changed.Node as MethodDeclarationSyntax)
+                     .Where(node => node != null).ToList();
+        }
+
+        private static IEnumerable<Tuple<ClassDeclarationSyntax, ClassDeclarationSyntax>>
+            MergeClassDeclarationSyntaxes(IEnumerable<ClassDeclarationSyntax> left,
+            IEnumerable<ClassDeclarationSyntax> rightE)
         {
             var right = rightE.ToList();
             foreach (var l in left)
@@ -159,26 +222,6 @@ namespace SemDiff.Core
                     yield return Tuple.Create(l, r);
                 }
             }
-        }
-
-        internal static string GetRelativePath(string localDirectory, string filePath)
-        {
-            var local = Path.GetFullPath(localDirectory);
-            var file = Path.GetFullPath(filePath);
-            if (file.StartsWith(local))
-            {
-                var relative = file.Substring(local.Length);
-                return relative.StartsWith(Path.DirectorySeparatorChar.ToString()) ? relative.Substring(1) : relative;
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        internal static IEnumerable<Tuple<RemoteFile, RemoteChanges>> GetPulls(Repo repo, string relativePath)
-        {
-            return repo.RemoteChangesData.Select(kvp => kvp.Value).SelectMany(p => p.Files.Select(f => new { n = f.Filename, f, p })).Where(a => a.n == relativePath).Select(a => Tuple.Create(a.f, a.p)).ToList();
         }
     }
 }

--- a/SemDiff.Core/Conflict.cs
+++ b/SemDiff.Core/Conflict.cs
@@ -7,6 +7,9 @@ using System.Text;
 
 namespace SemDiff.Core
 {
+    /// <summary>
+    /// Represents a conflicting changes between two files using a third ancestor file
+    /// </summary>
     public class Conflict
     {
         public SpanDetails Ancestor { get; set; }

--- a/SemDiff.Core/DataStore.cs
+++ b/SemDiff.Core/DataStore.cs
@@ -6,9 +6,13 @@ using System.Linq;
 
 namespace SemDiff.Core
 {
+    /// <summary>
+    /// Simplifies the retrieval of syntax trees based on the repo they are in and allows updating
+    /// the tree without relocating the repo based on the path
+    /// </summary>
     internal class DataStore
     {
-        //At the highest level we have a dictianary that maps the asembly
+        //At the highest level we have a dictionary that maps the assembly
         //name to info about the repository and it's files
         private ImmutableDictionary<string, RepoFileSyntaxTreeInfo> store =
                 ImmutableDictionary<string, RepoFileSyntaxTreeInfo>.Empty;
@@ -18,7 +22,7 @@ namespace SemDiff.Core
         public RepoFileSyntaxTreeInfo InterlockedAddOrUpdate(string assembly,
             IEnumerable<SyntaxTree> trees, Func<SyntaxTree, Repo> getRepoFunc)
         {
-            trees = trees.ToList(); //Posibly remove
+            trees = trees.ToList(); //Possibly remove
             return ImmutableInterlocked.AddOrUpdate(ref store,
                         assembly, s => InUpdate(trees, getRepoFunc),
                         (s, r) => InUpdate(trees, getRepoFunc, r));

--- a/SemDiff.Core/DetectedFalseNegative.cs
+++ b/SemDiff.Core/DetectedFalseNegative.cs
@@ -3,7 +3,8 @@
 namespace SemDiff.Core
 {
     /// <summary>
-    /// This class will hold all the important information about what kind of False Negative was detected and the files, pull requests, and changes involved
+    /// This class will hold all the important information about what kind of False Negative was
+    /// detected and the files, pull requests, and changes involved
     /// </summary>
     public class DetectedFalseNegative
     {
@@ -14,8 +15,8 @@ namespace SemDiff.Core
 
         public override string ToString()
         {
-            return $@"{nameof(DetectedFalseNegative)}: Location = {Location}, RemoteChange = {RemoteChange?.Url}, { ""
-                }RemoteFile = {RemoteFile.Filename}, TypeName = {TypeName}";
+            return $@"{nameof(DetectedFalseNegative)}: Location = {Location}, RemoteChange ={ ""
+                } {RemoteChange?.Url}, RemoteFile = {RemoteFile.Filename}, TypeName = {TypeName}";
         }
     }
 }

--- a/SemDiff.Core/DetectedFalsePositive.cs
+++ b/SemDiff.Core/DetectedFalsePositive.cs
@@ -3,7 +3,8 @@
 namespace SemDiff.Core
 {
     /// <summary>
-    /// This class will hold all the important information about what kind of False Positive was detected and the files, pull requests, and changes involved
+    /// This class will hold all the important information about what kind of False Positive was
+    /// detected and the files, pull requests, and changes involved
     /// </summary>
     public class DetectedFalsePositive
     {
@@ -13,15 +14,15 @@ namespace SemDiff.Core
             LocalMethodChanged
         }
 
-        public Location Location { get; internal set; }
-        public RemoteChanges RemoteChange { get; internal set; }
-        public RemoteFile RemoteFile { get; internal set; }
-        public ConflictTypes ConflictType { get; internal set; }
+        public Location Location { get; set; }
+        public RemoteChanges RemoteChange { get; set; }
+        public RemoteFile RemoteFile { get; set; }
+        public ConflictTypes ConflictType { get; set; }
 
         public override string ToString()
         {
-            return $@"{nameof(DetectedFalsePositive)}: Location = {Location}, RemoteChange = {RemoteChange?.Url}, { ""
-                }RemoteFile = {RemoteFile.Filename}, ConflictType = {ConflictType}";
+            return $@"{nameof(DetectedFalsePositive)}: Location = {Location}, RemoteChange ={ ""
+                } {RemoteChange?.Url}, RemoteFile = {RemoteFile.Filename}, ConflictType = {ConflictType}";
         }
     }
 }

--- a/SemDiff.Core/Diagnostics.cs
+++ b/SemDiff.Core/Diagnostics.cs
@@ -1,18 +1,30 @@
 ﻿using Microsoft.CodeAnalysis;
-using System;
 using System.Collections.Immutable;
 
 namespace SemDiff.Core
 {
     /// <summary>
-    /// This class provides our interface for reporting diagnostics using roslyn
+    /// This class provides our interface for reporting diagnostics using Roslyn
     /// </summary>
     public class Diagnostics
     {
         //Shared Values
         private const string Category = "Conflicts"; //Not sure where this shows up yet
 
-        //False-Negative
+        #region False-Positive
+
+        public const string FalsePositiveDiagnosticId = "SemDiffFP";
+
+        private const string FalsePositiveDescription = "False-Positives occur text based tools detect a conflict that affects the semantics of the application. i.e., when merge conflicts may occur, but there are no semantic differences between the conflicting changes.";
+
+        private const string FalsePositiveMessageFormat = "False-Positive between '{0}' and '({1})[{2}]'";
+
+        private const string FalsePositiveTitle = "Possible False-Positive condition detected";
+
+        #endregion False-Positive
+
+        #region False-Negative
+
         public const string FalseNegativeDiagnosticId = "SemDiffFN"; //Like the error code (just like missing semicolon is CS1002)
 
         private const string FalseNegativeDescription = "False-Negatives occur text based tools fail to detect a conflict that affects the semantics of the application. i.e., when the semantics of a dependant item (a called method, a base class, a variable used) has been changed in a way that changes the runtime of the application when the changes are merged.";
@@ -21,29 +33,20 @@ namespace SemDiff.Core
 
         private const string FalseNegativeTitle = "Possible False-Negative condition detected";
 
-        //False-Positive
-        public const string FalsePositiveDiagnosticId = "SemDiffFP";
+        #endregion False-Negative
 
-        private const string FalsePositiveDescription = "False-Positives occur text based tools detect a conflict that affects the semantics of the application. i.e., when merge conflicts may occur, but there are no semantic differences between the conflicting changes.";
+        #region InternalError
 
-        private const string FalsePositiveMessageFormat = "False-Positive between '{0}' and '({1})[{2}]'";
-
-        private const string FalsePositiveTitle = "Possible False-Positive condition detected"; //Not sure where this comes up yet
-
-        //InternalError
-        public const string InternalErrorDiagnosticId = "SemDiff";
+        public const string InternalErrorDiagnosticId = nameof(SemDiff);
 
         private const string InternalErrorMessageFormat = "SemDiff Error: {0}";
 
         private const string InternalErrorTitle = "SemDiff Internal Error";
 
-        //similar to fp
-        private static readonly DiagnosticDescriptor FalseNegative = new DiagnosticDescriptor(FalseNegativeDiagnosticId, FalseNegativeTitle, FalseNegativeMessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: FalseNegativeDescription);
+        #endregion InternalError
 
-        //0 is name of file, 1 is title of pull request, 2 is url of pull request //Actual error message text (formatable string)
-        //There is a option to show this in the error list for more info
         private static readonly DiagnosticDescriptor FalsePositive = new DiagnosticDescriptor(FalsePositiveDiagnosticId, FalsePositiveTitle, FalsePositiveMessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: FalsePositiveDescription);
-
+        private static readonly DiagnosticDescriptor FalseNegative = new DiagnosticDescriptor(FalseNegativeDiagnosticId, FalseNegativeTitle, FalseNegativeMessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: FalseNegativeDescription);
         private static readonly DiagnosticDescriptor InternalError = new DiagnosticDescriptor(InternalErrorDiagnosticId, InternalErrorTitle, InternalErrorMessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true);
 
         /// <summary>
@@ -52,38 +55,40 @@ namespace SemDiff.Core
         public static ImmutableArray<DiagnosticDescriptor> Supported { get; } = ImmutableArray.Create(FalsePositive, FalseNegative, InternalError);
 
         /// <summary>
-        /// Converts `DetectedFalsePositive`s to Diagnostics (the class provided by Roslyn) and sends them to the function provided
+        /// Converts `DetectedFalsePositive`s to Diagnostics (the class provided by Roslyn) and
+        /// sends them to the function provided
         /// </summary>
-        /// <param name="fps">todo: describe fps parameter on Convert</param>
+        /// <param name="fps">the object that contains the information to populate the error message</param>
         public static Diagnostic Convert(DetectedFalsePositive fps)
         {
             return Diagnostic.Create(FalsePositive, fps.Location, fps.RemoteFile.Filename, fps.RemoteChange.Title, fps.RemoteChange.Url);
         }
 
         /// <summary>
-        /// Converts `DetectedFalseNegative`s to Diagnostics (the class provided by Roslyn) and sends them to the function provided
+        /// Converts `DetectedFalseNegative`s to Diagnostics (the class provided by Roslyn) and
+        /// sends them to the function provided
         /// </summary>
-        /// <param name="fps">todo: describe fps parameter on Convert</param>
+        /// <param name="fns">the object that contains the information to populate the error message</param>
         public static Diagnostic Convert(DetectedFalseNegative fns)
         {
             return Diagnostic.Create(FalseNegative, fns.Location, fns.TypeName, fns.RemoteFile.Filename, fns.RemoteChange.Title, fns.RemoteChange.Url);
         }
 
         /// <summary>
-        /// Returns a diagnostic that represents a message that a repo was found but could a github url was not found.
+        /// Returns a diagnostic that represents a message that a repo was found but could a GitHub
+        /// url was not found.
         /// </summary>
         /// <param name="message">The exception message that should contain the path</param>
-        /// <returns></returns>
-        internal static Diagnostic NotGitHubRepo(string message)
+        public static Diagnostic NotGitHubRepo(string message)
         {
             return Diagnostic.Create(InternalError, Location.None, message);
         }
 
         /// <summary>
-        /// Returns a diagnostic that represents a friendly message that the rate limit has been exceeded and a link to our documention.
+        /// Returns a diagnostic that represents a friendly message that the rate limit has been
+        /// exceeded and a link to our documentation.
         /// </summary>
-        /// <returns></returns>
-        internal static Diagnostic RateLimit()
+        public static Diagnostic RateLimit()
         {
             return Diagnostic.Create(InternalError, Location.None, "The Rate Limit has been exceeded, please check documentation for information on how to increase the limit");
         }
@@ -97,11 +102,13 @@ namespace SemDiff.Core
         }
 
         /// <summary>
-        /// Should create a diagnostic that represents something like this: Unexpected Error Occured while ((verbNounPhrase))
+        /// Should create a diagnostic that represents something like this: Unexpected Error
+        /// Occurred while ((verbNounPhrase))
         /// </summary>
-        /// <param name="verbNounPhrase">Something like: Washing the Car, Mowing the Lawn, or Burning out a Fuze up here Alone</param>
-        /// <returns></returns>
-        internal static Diagnostic UnexpectedError(string verbNounPhrase)
+        /// <param name="verbNounPhrase">
+        /// Something like: Washing the Car, Mowing the Lawn, or Burning out a Fuse up here Alone
+        /// </param>
+        public static Diagnostic UnexpectedError(string verbNounPhrase)
         {
             return Diagnostic.Create(InternalError, Location.None, $"Unknown Error {verbNounPhrase}");
         }

--- a/SemDiff.Core/Diff.cs
+++ b/SemDiff.Core/Diff.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -8,26 +7,65 @@ using System.Text;
 namespace SemDiff.Core
 {
     /// <summary>
-    /// This class acts as a more detailed version of the TextChanged class that is better suited for our purposes
+    /// This class acts as a more detailed version of the TextChanged class that is better suited
+    /// for our purposes
     /// </summary>
     public class Diff
     {
         public SpanDetails Ancestor { get; set; }
         public SpanDetails Changed { get; set; }
 
-        public int OffsetStart => Changed.Span.Start - Ancestor.Span.Start;
         public int OffsetEnd => Changed.Span.End - Ancestor.Span.End;
+        public int OffsetStart => Changed.Span.Start - Ancestor.Span.Start;
 
+        /// <summary>
+        /// Generates Diff results for each change that occurred from the ancestor to the changed
+        /// </summary>
+        /// <param name="ancestor">
+        /// The abstract syntax tree that the changed version originated from
+        /// </param>
+        /// <param name="changed">The abstract syntax tree that resulted from changing the ancestor</param>
+        /// <returns>Changes between the ancestor and changed</returns>
+        public static IEnumerable<Diff> Compare(SyntaxTree ancestor, SyntaxTree changed)
+        {
+            var offset = 0; //Tracks differences in indexes moving through the changed syntax tree
+            foreach (var change in changed.GetChanges(ancestor))
+            { //Assumes that this list is sorted by place in file
+                var origLength = change.Span.Length;
+                var offsetChange = (change.NewText.Length - origLength);
+
+                var chanStart = change.Span.Start + offset;
+                var chanLength = origLength + offsetChange;
+
+                offset += offsetChange;
+
+                var d = new Diff
+                {
+                    Ancestor = SpanDetails.Create(change.Span, ancestor),
+                    Changed = SpanDetails.Create(new TextSpan(chanStart, chanLength), changed)
+                };
+
+                yield return d;
+            }
+        }
+
+        /// <summary>
+        /// Determine if the two diffs overlap
+        /// </summary>
+        /// <param name="diff1">One of the objects to test</param>
+        /// <param name="diff2">One of the objects to test</param>
+        /// <returns>true if the diffs overlap else false</returns>
         public static bool Intersects(Diff diff1, Diff diff2)
         {
             var start1 = diff1.Ancestor.Span.Start;
             var end1 = diff1.Ancestor.Span.End;
             var start2 = diff2.Ancestor.Span.Start;
             var end2 = diff2.Ancestor.Span.End;
-            return (start2 <= start1 && start1 <= end2) || (start1 <= start2 && start2 <= end1); //true if start of one is within start of the other (inclusive)
-        }
 
-        internal static bool IntersectsAny(Diff diff, IEnumerable<Diff> diffs) => diffs.Any(d => Intersects(diff, d));
+            //true if start of one is within start of the other (inclusive)
+            return (start2 <= start1 && start1 <= end2)
+                || (start1 <= start2 && start2 <= end1);
+        }
 
         /// <summary>
         /// Get a string that represents the differences in the file in a way that is readable
@@ -56,37 +94,31 @@ namespace SemDiff.Core
                 var dStart = d.Ancestor.Span.Start;
                 if (dStart > currentAncestorPos)
                 {
-                    builder.Append(ancestor.GetText().ToString(TextSpan.FromBounds(currentAncestorPos, dStart)));
+                    builder.Append(ancestor
+                                    .GetText()
+                                    .ToString(TextSpan.FromBounds(currentAncestorPos, dStart)));
                 }
                 builder.Append(d);
                 currentAncestorPos = d.Ancestor.Span.End;
             }
-            builder.Append(ancestor.GetText().ToString(TextSpan.FromBounds(currentAncestorPos, ancestor.Length)));
+            builder.Append(ancestor
+                            .GetText()
+                            .ToString(TextSpan.FromBounds(currentAncestorPos, ancestor.Length)));
             return builder.ToString();
-        }
-
-        public static IEnumerable<Diff> Compare(SyntaxTree ancestor, SyntaxTree changed)
-        {
-            var offset = 0; //Tracks the difference in indexes as we move through the changed syntax tree
-            foreach (var change in changed.GetChanges(ancestor)) //Assumption: I assume that this will allways be given sorted by place in file
-            {
-                var origLength = change.Span.Length;
-                var offsetChange = (change.NewText.Length - origLength);
-
-                var chanStart = change.Span.Start + offset;
-                var chanLength = origLength + offsetChange;
-
-                offset += offsetChange;
-
-                var d = new Diff { Ancestor = SpanDetails.Create(change.Span, ancestor), Changed = SpanDetails.Create(new TextSpan(chanStart, chanLength), changed) };
-
-                yield return d;
-            }
         }
 
         public override string ToString()
         {
             return $"<<<<<<<{Ancestor.Text}|||||||{Changed.Text}>>>>>>>";
         }
+
+        /// <summary>
+        /// Determines if a single diff intersects with any number of other diffs
+        /// </summary>
+        /// <param name="diff">single diff that will be compared against many</param>
+        /// <param name="diffs">multiple diffs that will be compared against a single diff</param>
+        /// <returns>true if an intersection occurs else false</returns>
+        public static bool IntersectsAny(Diff diff, IEnumerable<Diff> diffs)
+                                                        => diffs.Any(d => Intersects(diff, d));
     }
 }

--- a/SemDiff.Core/Diff3.cs
+++ b/SemDiff.Core/Diff3.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -10,12 +9,24 @@ namespace SemDiff.Core
     public static class Diff3
     {
         /// <summary>
-        /// Perform 3-way diff, this is done by comparing the changes to local and remote. This may result in conflicts if the changes overlap
+        /// Perform 3-way diff, this is done by comparing the changes to local and remote. This may
+        /// result in conflicts if the changes overlap
         /// </summary>
-        /// <param name="ancestor">The version that both local and remote decended from</param>
-        /// <param name="local">One set of changes, the local and remote params can be swapped without changing the result</param>
-        /// <param name="remote">One set of changes, the local and remote params can be swapped without changing the result</param>
-        /// <returns></returns>
+        /// <param name="ancestor">
+        /// A common version of the file that both local and remote derived from
+        /// </param>
+        /// <param name="local">
+        /// One version derived from the ancestor. The local and remote parameters are symmetric and
+        /// can be swapped
+        /// </param>
+        /// <param name="remote">
+        /// One version derived from the ancestor. The local and remote parameters are symmetric and
+        /// can be swapped
+        /// </param>
+        /// <returns>
+        /// An object that contains a list of all the conflicts that were detected as well as all
+        /// the changes and the trees
+        /// </returns>
         public static Diff3Result Compare(SyntaxTree ancestor, SyntaxTree local, SyntaxTree remote)
         {
             var localChanges = Diff.Compare(ancestor, local).ToList();
@@ -32,12 +43,14 @@ namespace SemDiff.Core
             };
         }
 
-        public static IEnumerable<Conflict> GetConflicts(IEnumerable<Diff> local, IEnumerable<Diff> remote, SyntaxTree ancestorTree, SyntaxTree localTree, SyntaxTree remoteTree)
+        private static IEnumerable<Conflict> GetConflicts(IEnumerable<Diff> local, IEnumerable<Diff> remote,
+            SyntaxTree ancestorTree, SyntaxTree localTree, SyntaxTree remoteTree)
         {
             var localChanges = local.Select(DiffWithOrigin.Local).ToList();
             var remoteChanges = remote.Select(DiffWithOrigin.Remote).ToList();
 
-            var changes = Extensions.GetMergedChangeQueue(localChanges, remoteChanges, d => d.Diff.Ancestor.Span.Start);
+            var changes = Extensions.GetMergedQueue(localChanges, remoteChanges,
+                                                            d => d.Diff.Ancestor.Span.Start);
             var potentialConflict = new List<DiffWithOrigin>();
             while (changes.Count > 0)
             {
@@ -47,7 +60,9 @@ namespace SemDiff.Core
                     var change = changes.Dequeue();
                     potentialConflict.Add(change);
                 }
-                while (changes.Count > 0 && Diff.IntersectsAny(changes.Peek().Diff, potentialConflict.Select(dwo => dwo.Diff)));
+                while (changes.Count > 0
+                      && Diff.IntersectsAny(changes.Peek().Diff,
+                                                   potentialConflict.Select(dwo => dwo.Diff)));
 
                 if (potentialConflict.Count >= 2)
                     yield return Conflict.Create(potentialConflict, ancestorTree, localTree, remoteTree);
@@ -57,7 +72,8 @@ namespace SemDiff.Core
 
         internal static Diff3Result Compare(SyntaxNode ancestor, SyntaxNode local, SyntaxNode remote)
         {
-            return Compare(SyntaxFactory.SyntaxTree(ancestor), SyntaxFactory.SyntaxTree(local), SyntaxFactory.SyntaxTree(remote));
+            return Compare(SyntaxFactory.SyntaxTree(ancestor),
+                                    SyntaxFactory.SyntaxTree(local), SyntaxFactory.SyntaxTree(remote));
         }
     }
 }

--- a/SemDiff.Core/Diff3Result.cs
+++ b/SemDiff.Core/Diff3Result.cs
@@ -1,16 +1,18 @@
 ﻿using Microsoft.CodeAnalysis;
-using System;
 using System.Collections.Generic;
 
 namespace SemDiff.Core
 {
+    /// <summary>
+    /// Used to store the results of a Diff3.Compare
+    /// </summary>
     public class Diff3Result
     {
-        public SyntaxTree AncestorTree { get; internal set; }
-        public IEnumerable<Conflict> Conflicts { get; internal set; }
-        public List<Diff> Local { get; internal set; }
-        public SyntaxTree LocalTree { get; internal set; }
-        public List<Diff> Remote { get; internal set; }
-        public SyntaxTree RemoteTree { get; internal set; }
+        public SyntaxTree AncestorTree { get; set; }
+        public IEnumerable<Conflict> Conflicts { get; set; }
+        public List<Diff> Local { get; set; }
+        public SyntaxTree LocalTree { get; set; }
+        public List<Diff> Remote { get; set; }
+        public SyntaxTree RemoteTree { get; set; }
     }
 }

--- a/SemDiff.Core/DiffWithOrigin.cs
+++ b/SemDiff.Core/DiffWithOrigin.cs
@@ -1,10 +1,24 @@
 ﻿namespace SemDiff.Core
 {
+    /// <summary>
+    /// A wrapper around Diff that adds a property that contains if the Diff was from comparing the
+    /// Local or Remote file
+    /// </summary>
     internal class DiffWithOrigin
     {
-        public static DiffWithOrigin Local(Diff diff) => new DiffWithOrigin { Diff = diff, Origin = OriginEnum.Local };
+        public static DiffWithOrigin Local(Diff diff) =>
+            new DiffWithOrigin
+            {
+                Diff = diff,
+                Origin = OriginEnum.Local
+            };
 
-        public static DiffWithOrigin Remote(Diff diff) => new DiffWithOrigin { Diff = diff, Origin = OriginEnum.Remote };
+        public static DiffWithOrigin Remote(Diff diff) =>
+            new DiffWithOrigin
+            {
+                Diff = diff,
+                Origin = OriginEnum.Remote
+            };
 
         public enum OriginEnum
         {

--- a/SemDiff.Core/Exceptions/GitHubAuthenticationFailureException.cs
+++ b/SemDiff.Core/Exceptions/GitHubAuthenticationFailureException.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.Serialization;
 
 namespace SemDiff.Core.Exceptions
 {
@@ -10,18 +9,6 @@ namespace SemDiff.Core.Exceptions
     public class GitHubAuthenticationFailureException : Exception
     {
         public GitHubAuthenticationFailureException() : base("Authentication Failure")
-        {
-        }
-
-        public GitHubAuthenticationFailureException(string message) : base(message)
-        {
-        }
-
-        public GitHubAuthenticationFailureException(string message, Exception innerException) : base(message, innerException)
-        {
-        }
-
-        protected GitHubAuthenticationFailureException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }

--- a/SemDiff.Core/Exceptions/GitHubDeserializationException.cs
+++ b/SemDiff.Core/Exceptions/GitHubDeserializationException.cs
@@ -1,28 +1,16 @@
 ﻿using System;
-using System.Runtime.Serialization;
 
 namespace SemDiff.Core.Exceptions
 {
     /// <summary>
-    /// Thrown when deserialization fails, this could happen because an error was returned and we did not catch in or it
-    /// could be any kind of corruped file
+    /// Thrown when deserialization fails, this could happen because an error was returned and we
+    /// did not catch in or it could be any kind of corrupted file
     /// </summary>
     [Serializable]
     public class GitHubDeserializationException : Exception
     {
-        public GitHubDeserializationException(Exception innerException) : base("Failed to Deserialize GitHub Data", innerException)
-        {
-        }
-
-        public GitHubDeserializationException(string message) : base(message)
-        {
-        }
-
-        public GitHubDeserializationException(string message, Exception innerException) : base(message, innerException)
-        {
-        }
-
-        protected GitHubDeserializationException(SerializationInfo info, StreamingContext context) : base(info, context)
+        public GitHubDeserializationException(Exception innerException)
+            : base("Failed to Deserialize GitHub Data", innerException)
         {
         }
     }

--- a/SemDiff.Core/Exceptions/GitHubRateLimitExceededException.cs
+++ b/SemDiff.Core/Exceptions/GitHubRateLimitExceededException.cs
@@ -1,28 +1,16 @@
 ﻿using System;
-using System.Runtime.Serialization;
 
 namespace SemDiff.Core.Exceptions
 {
     /// <summary>
-    /// This can ALSO be thrown if the maximum login attempts is exceeded
-    /// Thrown when github reports that the rate limit has been exceeded, this could happen with an unauthenticated client or authenticated clients. The latter is more likely though.
+    /// Thrown when GitHub reports that the rate limit has been exceeded, this could happen with an
+    /// unauthenticated client or authenticated clients. This can also be thrown if the maximum
+    /// login attempts is exceeded. The latter is more likely though.
     /// </summary>
     [Serializable]
     public class GitHubRateLimitExceededException : Exception
     {
         public GitHubRateLimitExceededException() : base("Rate Limit Exceeded")
-        {
-        }
-
-        public GitHubRateLimitExceededException(string message) : base(message)
-        {
-        }
-
-        public GitHubRateLimitExceededException(string message, Exception innerException) : base(message, innerException)
-        {
-        }
-
-        protected GitHubRateLimitExceededException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }

--- a/SemDiff.Core/Exceptions/GitHubUnknownErrorException.cs
+++ b/SemDiff.Core/Exceptions/GitHubUnknownErrorException.cs
@@ -1,27 +1,14 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.Serialization;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace SemDiff.Core.Exceptions
 {
     /// <summary>
-    /// This exception is thrown if an error is recieved that is unhandled or un documented
+    /// This exception is thrown if an error is received that is unhandled or undocumented
     /// </summary>
     [Serializable]
     public class GitHubUnknownErrorException : Exception
     {
         internal GitHubUnknownErrorException(string message) : base(message)
-        {
-        }
-
-        public GitHubUnknownErrorException(string message, Exception innerException) : base(message, innerException)
-        {
-        }
-
-        protected GitHubUnknownErrorException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }

--- a/SemDiff.Core/Exceptions/GitHubUrlNotFoundException.cs
+++ b/SemDiff.Core/Exceptions/GitHubUrlNotFoundException.cs
@@ -1,19 +1,15 @@
 ﻿using System;
-using System.Runtime.Serialization;
 
 namespace SemDiff.Core.Exceptions
 {
     /// <summary>
-    /// Thrown if we find a gitconfig file, but it doesnt match our regex for a github url
+    /// Thrown if we find a .gitconfig file, but it doesn't match our reg-ex for a GitHub url
     /// </summary>
     [Serializable]
     internal class GitHubUrlNotFoundException : Exception
     {
-        public GitHubUrlNotFoundException(string path) : base($"Repo '{path}' dosn't seem to be a GitHub repository.")
-        {
-        }
-
-        protected GitHubUrlNotFoundException(SerializationInfo info, StreamingContext context) : base(info, context)
+        public GitHubUrlNotFoundException(string path)
+            : base($"Repository at '{path}' doesn't seem to be a GitHub repository.")
         {
         }
     }

--- a/SemDiff.Core/Extensions.cs
+++ b/SemDiff.Core/Extensions.cs
@@ -5,13 +5,24 @@ using System.Threading.Tasks;
 
 namespace SemDiff.Core
 {
+    /// <summary>
+    /// Contains Extension methods
+    /// </summary>
     public static class Extensions
     {
-        public static Queue<T> ToQueue<T>(this IEnumerable<T> source) => new Queue<T>(source);
-
-        public static IEnumerable<T> Log<T>(this IEnumerable<T> source, Action<T> loggingAction) => source.Select(o => { loggingAction?.Invoke(o); return o; });
-
-        public static Queue<T> GetMergedChangeQueue<T>(this IEnumerable<T> left, IEnumerable<T> right, Func<T, int> selector)
+        /// <summary>
+        /// Merges two IEnumerable into a queue in an order based on an integer value
+        /// </summary>
+        /// <typeparam name="T">type parameter should be inferred by the compiler</typeparam>
+        /// <param name="left">source enumerable</param>
+        /// <param name="right">source enumerable</param>
+        /// <param name="selector">
+        /// a function that gets the integer value that the queue will be ordered by
+        /// </param>
+        /// <returns>
+        /// A queue that contains the sources in an order based on the values provided by selector
+        /// </returns>
+        public static Queue<T> GetMergedQueue<T>(this IEnumerable<T> left, IEnumerable<T> right, Func<T, int> selector)
         {
             var leftQueue = left.ToQueue();
             var rightQueue = right.ToQueue();
@@ -49,6 +60,26 @@ namespace SemDiff.Core
             return result;
         }
 
+        /// <summary>
+        /// Executes a logging action for each item in an IEnumerable. Logging action will be
+        /// executed as each item is used Note that the output of this function must be consumed in
+        /// order to execute the logging action
+        /// </summary>
+        /// <typeparam name="T">type parameter should be inferred by the compiler</typeparam>
+        /// <param name="source">list of <typeparamref name="T"/></param>
+        /// <param name="loggingAction">action that will be called for every item in the list</param>
+        /// <returns>the source items unchanged, but in a new IEnumerable</returns>
+        public static IEnumerable<T> Log<T>(this IEnumerable<T> source, Action<T> loggingAction)
+            => source.Select(o => { loggingAction?.Invoke(o); return o; });
+
+        /// <summary>
+        /// Executes a task, if it throws an exception then execute it again after a delay. If it
+        /// fails again the error will not be caught
+        /// </summary>
+        /// <typeparam name="T">inferred by the compiler</typeparam>
+        /// <param name="tsk">A function that produces the task to execute</param>
+        /// <param name="wait">The amount of time to wait between failure and second try</param>
+        /// <returns></returns>
         public async static Task<T> RetryOnceAsync<T>(this Func<Task<T>> tsk, TimeSpan wait)
         {
             try
@@ -62,5 +93,14 @@ namespace SemDiff.Core
                 return await tsk?.Invoke();
             }
         }
+
+        /// <summary>
+        /// Creates a new queue from a list of items, a shortcut to prevent typing the <typeparamref
+        /// name="T"/> parameter
+        /// </summary>
+        /// <typeparam name="T">type parameter should be inferred by the compiler</typeparam>
+        /// <param name="source">list of <typeparamref name="T"/></param>
+        /// <returns>A queue that contains the source</returns>
+        public static Queue<T> ToQueue<T>(this IEnumerable<T> source) => new Queue<T>(source);
     }
 }

--- a/SemDiff.Core/GitHub.cs
+++ b/SemDiff.Core/GitHub.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.CodeAnalysis.CSharp;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
-using SemDiff.Core;
 using SemDiff.Core.Exceptions;
 using System;
 using System.Collections.Generic;
@@ -17,10 +16,13 @@ using System.Threading.Tasks;
 namespace SemDiff.Core
 {
     /// <summary>
-    /// Contains all the methods and classes nessasary to use the GitHub api to pull down data about pull requests. Additionally, contains the logic for authenticating
+    /// Contains all the methods and classes necessary to use the GitHub api to pull down data about
+    /// pull requests. Additionally, contains the logic for authenticating
     /// </summary>
     public class GitHub
     {
+        private static readonly Regex nextLinkPattern = new Regex("<(http[^ ]*)>; *rel *= *\"next\"");
+
         public GitHub(string repoOwner, string repoName, string authUsername = null, string authToken = null)
         {
             Logger.Info($"{nameof(GitHub)}: {authUsername}:{authToken} for {repoOwner}\\{repoName}");
@@ -47,31 +49,128 @@ namespace SemDiff.Core
 
         public string AuthToken { get; set; }
         public string AuthUsername { get; set; }
-        public string RepoName { get; set; }
-        public string RepoOwner { get; set; }
-        public int RequestsRemaining { get; private set; }
-        public int RequestsLimit { get; private set; }
         public HttpClient Client { get; private set; }
-        public string RepoFolder { get; set; }
         public IList<PullRequest> CurrentSaved { get; set; }
         public string EtagNoChanges { get; set; }
         public string JsonFileName { get; } = "LocalList.json";
+        public string RepoFolder { get; set; }
+        public string RepoName { get; set; }
+        public string RepoOwner { get; set; }
+        public int RequestsLimit { get; private set; }
+        public int RequestsRemaining { get; private set; }
 
-        internal void GetCurrentSaved()
+        /// <summary>
+        /// Download files for a given pull request. Store the files in the AppData folder with a
+        /// sub-folder for the pull request
+        /// </summary>
+        /// <param name="pr">the PullRequest for which the files need to be downloaded</param>
+        public async Task DownloadFilesAsync(PullRequest pr)
         {
-            try
+            foreach (var current in pr.Files)
             {
-                var path = RepoFolder.Replace('/', Path.DirectorySeparatorChar);
-                path = Path.Combine(path, JsonFileName);
-                var json = File.ReadAllText(path);
-                CurrentSaved = JsonConvert.DeserializeObject<IList<PullRequest>>(json);
+                if (pr.LastWrite >= pr.Updated)
+                    return;
+                var csFileTokens = current.Filename.Split('.');
+                if (csFileTokens.Last() == "cs")
+                {
+                    switch (current.Status)
+                    {
+                        case Files.StatusEnum.Added:
+                        case Files.StatusEnum.Removed:
+                        case Files.StatusEnum.Renamed: //Not sure how to handle this one...
+                            break;
+
+                        case Files.StatusEnum.Changed:
+                            Logger.Info($"The mythical 'changed' status has occured! {pr.Number}:{current.Filename}");
+                            goto case Files.StatusEnum.Modified; //Effectivly falls through to the following
+
+                        case Files.StatusEnum.Modified:
+                            var headTsk = DownloadFileAsync(pr.Number, current.Filename, pr.Head.Sha);
+                            var ancTsk = DownloadFileAsync(pr.Number, current.Filename, pr.Base.Sha, isAncestor: true);
+                            await Task.WhenAll(headTsk, ancTsk);
+                            break;
+                    }
+                }
             }
-            catch(Exception ex)
-            {
-                Logger.Error($"{ex.GetType().Name}: Couldn't load {JsonFileName} because {ex.Message}");
-            }
+            pr.LastWrite = DateTime.UtcNow;
         }
 
+        /// <summary>
+        /// Gets each page of the pull request list from GitHub. Once the list is complete, get all
+        /// the pull request files for each pull request.
+        /// </summary>
+        /// <returns>List of pull request information.</returns>
+        public async Task<IList<PullRequest>> GetPullRequestsAsync()
+        {
+            var url = $"/repos/{RepoOwner}/{RepoName}/pulls";
+            var etag = Ref.Create(EtagNoChanges);
+            var pagination = Ref.Create<string>(null);
+            var paginationPRs = await HttpGetAsync<IList<PullRequest>>(url, etag, pagination);
+            EtagNoChanges = etag.Value;
+            var pullRequests = paginationPRs;
+            while (paginationPRs != null)
+            {
+                paginationPRs = null;
+                if (pagination.Value != null)
+                {
+                    paginationPRs = await HttpGetAsync<IList<PullRequest>>(pagination.Value, pages: pagination);
+                    foreach (var cur in paginationPRs)
+                    {
+                        pullRequests.Add(cur);
+                    }
+                }
+            }
+            if (pullRequests == null)
+            {
+                return null;
+            }
+            if (CurrentSaved != null)
+            {
+                var removePRs = CurrentSaved;
+                foreach (var pr in pullRequests)
+                {
+                    foreach (var prRemove in removePRs)
+                    {
+                        if (pr.Number == prRemove.Number)
+                        {
+                            pr.LastWrite = prRemove.LastWrite;
+                            removePRs.Remove(prRemove);
+                            break;
+                        }
+                    }
+                }
+                DeletePRsFromDisk(removePRs);
+            }
+            CurrentSaved = pullRequests;
+            return await Task.WhenAll(pullRequests.Select(async pr =>
+            {
+                var filePagination = Ref.Create<string>(null);
+                var files = await HttpGetAsync<IList<Files>>($"/repos/{RepoOwner}/{RepoName}/pulls/{pr.Number}/files", pages: filePagination);
+                pr.Files = files;
+                files = null;
+                while (filePagination.Value != null)
+                {
+                    files = await HttpGetAsync<IList<Files>>(filePagination.Value, pages: filePagination);
+                    foreach (var cur in files)
+                    {
+                        pr.Files.Add(cur);
+                    }
+                }
+                return pr;
+            }));
+        }
+
+        /// <summary>
+        /// Makes a request to GitHub to update RequestsRemaining and RequestsLimit
+        /// </summary>
+        public Task UpdateLimitAsync()
+        {
+            return HttpGetAsync("/rate_limit");
+        }
+
+        /// <summary>
+        /// Write the current internal list of pull requests to a file
+        /// </summary>
         public void UpdateLocalSavedList()
         {
             var path = RepoFolder.Replace('/', Path.DirectorySeparatorChar);
@@ -80,20 +179,114 @@ namespace SemDiff.Core
             File.WriteAllText(path, JsonConvert.SerializeObject(CurrentSaved));
         }
 
-
         /// <summary>
-        /// Makes a request to github to update RequestsRemaining and RequestsLimit
+        /// Construct the absolute path of a file in a pull request
         /// </summary>
-        public Task UpdateLimitAsync()
+        /// <param name="repofolder">the path to the repo in the AppData folder</param>
+        /// <param name="prNum">number property of pull request</param>
+        /// <param name="path">the relative path of the file in the repo</param>
+        /// <param name="isAncestor">if true appends the additional orig extension</param>
+        /// <returns></returns>
+        internal static string GetPathInCache(string repofolder, int prNum, string path, bool isAncestor = false)
         {
-            return HttpGetAsync("/rate_limit");
+            var dir = Path.Combine(repofolder, $"{prNum}", path.Replace('/', '\\'));
+
+            if (isAncestor)
+            {
+                dir += ".orig";
+            }
+
+            return dir;
         }
 
         /// <summary>
-        /// Make a request to GitHub with nessasary checks, then parse the result into the specified type
+        /// Reads the pull requests from the persistent file
+        /// </summary>
+        public void GetCurrentSaved()
+        {
+            try
+            {
+                var path = RepoFolder.Replace('/', Path.DirectorySeparatorChar);
+                path = Path.Combine(path, JsonFileName);
+                var json = File.ReadAllText(path);
+                CurrentSaved = JsonConvert.DeserializeObject<IList<PullRequest>>(json);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"{ex.GetType().Name}: Couldn't load {JsonFileName} because {ex.Message}");
+            }
+        }
+
+        private static T DeserializeWithErrorHandling<T>(string content)
+        {
+            try
+            {
+                return JsonConvert.DeserializeObject<T>(content);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"{nameof(GitHubDeserializationException)}: {ex.Message}");
+                throw new GitHubDeserializationException(ex);
+            }
+        }
+
+        private static string ParseNextLink(IEnumerable<string> links)
+        {
+            foreach (var l in links)
+            {
+                var match = nextLinkPattern.Match(l);
+                if (match.Success)
+                {
+                    return match.Groups[1].Value;
+                }
+            }
+            return null;
+        }
+
+        private void DeletePRsFromDisk(IEnumerable<PullRequest> prs)
+        {
+            foreach (var pr in prs)
+            {
+                var dir = Path.Combine(RepoFolder, $"{pr.Number}");
+                try
+                {
+                    Directory.Delete(dir, true);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error($"{ex.GetType().Name}: Couldn't load {JsonFileName} because {ex.Message}");
+                }
+            }
+        }
+
+        private async Task DownloadFileAsync(int prNum, string path, string sha, bool isAncestor = false)
+        {
+            var rawText = await HttpGetAsync($@"https://github.com/{RepoOwner}/{RepoName}/raw/{sha}/{path}");
+            path = path.Replace('/', Path.DirectorySeparatorChar);
+            var dir = GetPathInCache(RepoFolder, prNum, path, isAncestor);
+            new FileInfo(dir).Directory.Create();
+            File.WriteAllText(dir, rawText);
+        }
+
+        /// <summary>
+        /// Make a request to GitHub with necessary checks, then parse the result into the specified type
         /// </summary>
         /// <param name="url">relative url to the requested resource</param>
+        /// <param name="etag">
+        /// An optional special object that contains a string that can be changed, if the parameter
+        /// is present and the string inside is not null it will be placed in the IfNotModified
+        /// HttpHeader otherwise if it is present but the string inside is null then any Etag found
+        /// on the response header will be set in the object
+        /// </param>
+        /// <param name="pages">
+        /// if not null and the response had a link to a next page the value inside will be set to
+        /// the url of the next page
+        /// </param>
         /// <typeparam name="T">Type the request is expected to contain</typeparam>
+        /// <returns>
+        /// A Task that once awaited will result in the pages contents being deserialized into the
+        /// return object
+        /// </returns>
         private async Task<T> HttpGetAsync<T>(string url, Ref<string> etag = null, Ref<string> pages = null) where T : class
         {
             var content = await HttpGetAsync(url, etag, pages);
@@ -155,190 +348,74 @@ namespace SemDiff.Core
             return await response.Content.ReadAsStringAsync();
         }
 
-        private static Regex nextLinkPattern = new Regex("<(http[^ ]*)>; *rel *= *\"next\"");
-
-        private static string ParseNextLink(IEnumerable<string> links)
+        /// <summary>
+        /// Object used for parsing that reflects the json of the object that GitHub uses for files
+        /// </summary>
+        public class Files
         {
-            foreach (var l in links)
+            public enum StatusEnum
             {
-                var match = nextLinkPattern.Match(l);
-                if (match.Success)
-                {
-                    return match.Groups[1].Value;
-                }
+                Added,
+                Modified,
+                Removed,
+                Renamed,
+
+                //Mostly undocumented, occurs rarely
+                //Seems to show up when only the file permissions were changed
+                //or if there are too many files it the pull request (more than about 200)
+                Changed
             }
-            return null;
-        }
 
-        private void DeletePRsFromDisk(IEnumerable<PullRequest> prs)
-        {
-            foreach (var pr in prs)
+            public string Filename { get; set; }
+
+            [JsonConverter(typeof(StringEnumConverter))]
+            public StatusEnum Status { get; set; }
+
+            internal RemoteFile ToRemoteFile(string repofolder, int num)
             {
-                var dir = Path.Combine(RepoFolder, $"{pr.Number}");
-                try
+                var baseP = GetPathInCache(repofolder, num, Filename, isAncestor: true);
+                var fileP = GetPathInCache(repofolder, num, Filename, isAncestor: false);
+                return new RemoteFile
                 {
-                    Directory.Delete(dir, true);
-                }
-                catch(Exception ex)
-                {
-                    Logger.Error($"{ex.GetType().Name}: Couldn't load {JsonFileName} because {ex.Message}");
-                }
+                    Filename = Filename,
+                    Base = CSharpSyntaxTree.ParseText(File.ReadAllText(baseP), path: baseP),
+                    File = CSharpSyntaxTree.ParseText(File.ReadAllText(fileP), path: fileP)
+                };
             }
         }
 
         /// <summary>
-        /// Gets each page of the pull request list from GitHub.
-        /// Once the list is complete, get all the pull request files for each pull request.
+        /// Object used for parsing that reflects the json of the object that GitHub uses inside of
+        /// the pull request object
         /// </summary>
-        /// <returns>List of pull request information.</returns>
-        public async Task<IList<PullRequest>> GetPullRequestsAsync()
+        public class HeadBase
         {
-            //TODO: Investigate using the If-Modified-Since and If-None-Match headers https://developer.github.com/v3/#conditional-requests
-            var url = $"/repos/{RepoOwner}/{RepoName}/pulls";
-            var etag = Ref.Create(EtagNoChanges);
-            var pagination = Ref.Create<string>(null);
-            var paginationPRs = await HttpGetAsync<IList<PullRequest>>(url, etag, pagination);
-            EtagNoChanges = etag.Value;
-            var pullRequests = paginationPRs;
-            while (paginationPRs != null)
-            {
-                paginationPRs = null;
-                if (pagination.Value != null)
-                {
-                    paginationPRs = await HttpGetAsync<IList<PullRequest>>(pagination.Value, pages: pagination);
-                    foreach (var cur in paginationPRs)
-                    {
-                        pullRequests.Add(cur);
-                    }
-                }
-            }
-            if (pullRequests == null)
-            {
-                return null;
-            }
-            if (CurrentSaved != null)
-            {
-                var removePRs = CurrentSaved;
-                foreach (var pr in pullRequests)
-                {
-                    foreach (var prRemove in removePRs)
-                    {
-                        if (pr.Number == prRemove.Number)
-                        {
-                            pr.LastWrite = prRemove.LastWrite;
-                            removePRs.Remove(prRemove);
-                            break;
-                        }
-                    }
-                }
-                DeletePRsFromDisk(removePRs);
-            }
-            CurrentSaved = pullRequests;
-            return await Task.WhenAll(pullRequests.Select(async pr =>
-            {
-                var filePagination = Ref.Create<string>(null);
-                var files = await HttpGetAsync<IList<Files>>($"/repos/{RepoOwner}/{RepoName}/pulls/{pr.Number}/files",pages: filePagination);
-                pr.Files = files;
-                files = null;
-                while(filePagination.Value != null)
-                {
-                    files = await HttpGetAsync<IList<Files>>(filePagination.Value, pages: filePagination);
-                    foreach(var cur in files)
-                    {
-                        pr.Files.Add(cur);
-                    }
-                }
-                return pr;
-            }));
+            public string Label { get; set; }
+            public string Ref { get; set; }
+            public string Sha { get; set; }
         }
 
         /// <summary>
-        /// Download files for a given pull request.
-        /// Store the files in the AppData folder with a subfolder for the pull request
+        /// Object used for parsing that reflects the json of the object that GitHub uses for Pull Requests
         /// </summary>
-        /// <param name="pr">the PullRequest for which the files need to be downloaded</param>
-        public async Task DownloadFilesAsync(PullRequest pr)
-        {
-            foreach (var current in pr.Files)
-            {
-                if (pr.LastWrite >= pr.Updated)
-                    return;
-                var csFileTokens = current.Filename.Split('.');
-                if (csFileTokens.Last() == "cs")
-                {
-                    switch (current.Status)
-                    {
-                        case Files.StatusEnum.Added:
-                        case Files.StatusEnum.Removed:
-                        case Files.StatusEnum.Renamed: //Not sure how to handle this one...
-                            break;
-
-                        case Files.StatusEnum.Changed:
-                            Logger.Info($"The mythical 'changed' status has occured! {pr.Number}:{current.Filename}");
-                            goto case Files.StatusEnum.Modified; //Effectivly falls through to the following
-
-                        case Files.StatusEnum.Modified: 
-                            var headTsk = DownloadFileAsync(pr.Number, current.Filename, pr.Head.Sha);
-                            var ancTsk = DownloadFileAsync(pr.Number, current.Filename, pr.Base.Sha, isAncestor: true);
-                            await Task.WhenAll(headTsk, ancTsk);
-                            break;
-                    }
-                }
-            }
-            pr.LastWrite = DateTime.UtcNow;
-        }
-
-        private async Task DownloadFileAsync(int prNum, string path, string sha, bool isAncestor = false)
-        {
-            var rawText = await HttpGetAsync($@"https://github.com/{RepoOwner}/{RepoName}/raw/{sha}/{path}");
-            path = path.Replace('/', Path.DirectorySeparatorChar);
-            var dir = GetPathInCache(RepoFolder, prNum, path, isAncestor);
-            new FileInfo(dir).Directory.Create();
-            File.WriteAllText(dir, rawText);
-        }
-
-        internal static string GetPathInCache(string repofolder, int prNum, string path, bool isAncestor = false)
-        {
-            var dir = Path.Combine(repofolder, $"{prNum}", path.Replace('/', '\\'));
-
-            if (isAncestor)
-            {
-                dir += ".orig";
-            }
-
-            return dir;
-        }
-
-        private static T DeserializeWithErrorHandling<T>(string content)
-        {
-            try
-            {
-                return JsonConvert.DeserializeObject<T>(content);
-            }
-            catch (Exception ex)
-            {
-                Logger.Error($"{nameof(GitHubDeserializationException)}: {ex.Message}");
-                throw new GitHubDeserializationException(ex);
-            }
-        }
-
         public class PullRequest
         {
+            public HeadBase Base { get; set; }
+            public IList<Files> Files { get; set; }
+            public HeadBase Head { get; set; }
+            public DateTime LastWrite { get; set; } = DateTime.MinValue;
+            public bool Locked { get; set; }
             public int Number { get; set; }
             public string State { get; set; }
             public string Title { get; set; }
-            public bool Locked { get; set; }
 
             [JsonProperty("updated_at")]
             public DateTime Updated { get; set; }
-            public DateTime LastWrite { get; set; } = DateTime.MinValue;
+
             [JsonProperty("html_url")]
             public string Url { get; set; }
 
             public User User { get; set; }
-            public HeadBase Head { get; set; }
-            public HeadBase Base { get; set; }
-            public IList<Files> Files { get; set; }
 
             internal RemoteChanges ToRemoteChanges(string repofolder)
             {
@@ -356,59 +433,23 @@ namespace SemDiff.Core
             }
         }
 
-        public class Files
-        {
-            public string Filename { get; set; }
-
-            [JsonConverter(typeof(StringEnumConverter))]
-            public StatusEnum Status { get; set; }
-
-            internal RemoteFile ToRemoteFile(string repofolder, int num)
-            {
-                var baseP = GetPathInCache(repofolder, num, Filename, isAncestor: true);
-                var fileP = GetPathInCache(repofolder, num, Filename, isAncestor: false);
-                return new RemoteFile
-                {
-                    Filename = Filename,
-                    Base = CSharpSyntaxTree.ParseText(File.ReadAllText(baseP), path: baseP),
-                    File = CSharpSyntaxTree.ParseText(File.ReadAllText(fileP), path: fileP)
-                };
-            }
-
-            //[JsonProperty("raw_url")]
-            //public string RawUrl { get; set; }
-            public enum StatusEnum
-            {
-                Added,
-                Modified,
-                Removed,
-                Renamed,
-
-                //Mostly undocumented, occurs rarely
-                //Seems to show up when only the file permissions were changed
-                //or if there are too many files it the pull request (more than about 200)
-                Changed
-            }
-        }
-
+        /// <summary>
+        /// Object used for parsing that reflects the json object that GitHub uses to represent users.
+        /// </summary>
         public class User
         {
             public string Login { get; set; }
         }
 
-        public class HeadBase
-        {
-            public string Label { get; set; }
-            public string Ref { get; set; }
-            public string Sha { get; set; }
-        }
-
+        /// <summary>
+        /// Object used for parsing that reflects the json of the response from GitHub in an error
+        /// </summary>
         internal class GitHubError
         {
-            public string Message { get; set; }
-
             [JsonProperty("documentation_url")]
             public string DocumentationUrl { get; set; }
+
+            public string Message { get; set; }
 
             internal Exception ToException()
             {

--- a/SemDiff.Core/GitHubConfiguration.cs
+++ b/SemDiff.Core/GitHubConfiguration.cs
@@ -1,9 +1,4 @@
 ﻿using SemDiff.Core.Configuration;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace SemDiff.Core
 {

--- a/SemDiff.Core/Logger.cs
+++ b/SemDiff.Core/Logger.cs
@@ -9,14 +9,14 @@ namespace SemDiff.Core
 {
     /// <summary>
     /// Used for logging important events, uses the Caller* attributes to collect more data than a
-    /// simple print. A date is also added to the ouput along with the severity (Debug, Info, Error)
+    /// simple print. A date is also added to the output along with the severity (Debug, Info, Error)
     /// matching the function called
     /// </summary>
     /// <example>Logger.Error(exception.Message)</example>
     internal static class Logger
     {
         public static ImmutableArray<Action<string>> Hooks { get; private set; } = ImmutableArray<Action<string>>.Empty;
-        private static bool enabled = false;
+        private static bool enabled;
         private static Severities[] enabledSeverities = Array.Empty<Severities>();
 
         private static void Log(Severities severity, string message, string callerFilePath, string callerMemberName, int callerLineNumber)
@@ -28,10 +28,10 @@ namespace SemDiff.Core
         }
 
         /// <summary>
-        /// Suppress the suplied severites from being logged. Everytime this command is run it will
+        /// Suppress the supplied severities from being logged. Every time this command is run it will
         /// replace the previously suppressed commands
         /// </summary>
-        /// <param name="supressed">Severity levels to supress</param>
+        /// <param name="supressed">Severity levels to suppress</param>
         public static void Suppress(params Severities[] supressed)
         {
             enabledSeverities = Enum.GetValues(typeof(Severities))
@@ -40,6 +40,10 @@ namespace SemDiff.Core
                     .ToArray();
         }
 
+        /// <summary>
+        /// Add a way to log each message
+        /// </summary>
+        /// <param name="hook">a function that will take the string to log and perform some action with it</param>
         public static void AddHooks(Action<string> hook)
         {
             enabled = true;
@@ -54,7 +58,11 @@ namespace SemDiff.Core
             }
         }
 
-        //This is a dirty way to log, because we have to lock around the writing and the file never closed. A better way would be a small database.
+        /// <summary>
+        /// Produces a Hook that will log to file
+        /// </summary>
+        /// <param name="fileName">path to the log file</param>
+        /// <returns>an action that can be passed to AddHooks</returns>
         public static Action<string> LogToFile(string fileName)
         {
             var file = File.AppendText(fileName);
@@ -70,17 +78,45 @@ namespace SemDiff.Core
 
         public static Action<string> LogToTrace { get; } = m => SysTrace.WriteLine(m); //SysTrace is alias for Trace
 
+        /// <summary>
+        /// Log a event with Trace severity, such as logging the entry and exit of functions or other very verbose information
+        /// </summary>
+        /// <param name="m">string that will be logged</param>
+        /// <param name="cfp">supplied by compiler</param>
+        /// <param name="cmn">supplied by compiler</param>
+        /// <param name="cln">supplied by compiler</param>
         public static void Trace(string m, [CallerFilePath] string cfp = "", [CallerMemberName] string cmn = "", [CallerLineNumber] int cln = 0) => Log(Severities.Trace, m, cfp, cmn, cln);
 
+        /// <summary>
+        /// Log a event with Debug severity, such as hitting a special condition or location in the program, can be used for "printf" debugging
+        /// </summary>
+        /// <param name="m">string that will be logged</param>
+        /// <param name="cfp">supplied by compiler</param>
+        /// <param name="cmn">supplied by compiler</param>
+        /// <param name="cln">supplied by compiler</param>
         public static void Debug(string m, [CallerFilePath] string cfp = "", [CallerMemberName] string cmn = "", [CallerLineNumber] int cln = 0) => Log(Severities.Debug, m, cfp, cmn, cln);
 
+        /// <summary>
+        /// Log a event with Info severity, such as an important event like a password change
+        /// </summary>
+        /// <param name="m">string that will be logged</param>
+        /// <param name="cfp">supplied by compiler</param>
+        /// <param name="cmn">supplied by compiler</param>
+        /// <param name="cln">supplied by compiler</param>
         public static void Info(string m, [CallerFilePath] string cfp = "", [CallerMemberName] string cmn = "", [CallerLineNumber] int cln = 0) => Log(Severities.Info, m, cfp, cmn, cln);
 
+        /// <summary>
+        /// Log a event with Error severity, such as exceptions or unhandled conditions.
+        /// </summary>
+        /// <param name="m">string that will be logged</param>
+        /// <param name="cfp">supplied by compiler</param>
+        /// <param name="cmn">supplied by compiler</param>
+        /// <param name="cln">supplied by compiler</param>
         public static void Error(string m, [CallerFilePath] string cfp = "", [CallerMemberName] string cmn = "", [CallerLineNumber] int cln = 0) => Log(Severities.Error, m, cfp, cmn, cln);
 
         /// <summary>
         /// A Severity is a tag that is added to the error message. Levels of errors that get
-        /// progressivly worse.
+        /// progressively worse.
         /// </summary>
         public enum Severities
         {

--- a/SemDiff.Core/Ref.cs
+++ b/SemDiff.Core/Ref.cs
@@ -1,8 +1,6 @@
-﻿using System;
-
-namespace SemDiff.Core
+﻿namespace SemDiff.Core
 {
-    public static class Ref
+    internal static class Ref
     {
         public static Ref<T> Create<T>(T initialValue)
         {
@@ -13,7 +11,7 @@ namespace SemDiff.Core
         }
     }
 
-    public class Ref<T>
+    internal class Ref<T>
     {
         internal Ref()
         {

--- a/SemDiff.Core/RemoteFile.cs
+++ b/SemDiff.Core/RemoteFile.cs
@@ -2,6 +2,9 @@
 
 namespace SemDiff.Core
 {
+    /// <summary>
+    /// Represents files that are part of a RemoteChange
+    /// </summary>
     public class RemoteFile
     {
         /// <summary>

--- a/SemDiff.Core/SemDiff.nuspec
+++ b/SemDiff.Core/SemDiff.nuspec
@@ -16,7 +16,7 @@
       This is a community project, free and open source. Everyone is invited to contribute, fork, share and use the code. No money shall be charged by this software, nor it will be. Ever.
     </description>
     <summary>Tool which can diff C# code semantically, rather than simply by the program's text</summary>
-    <releaseNotes>Initial Release</releaseNotes>
+    <releaseNotes>Initial Packaged Release - This is a beta release and may have bugs or cause crashes</releaseNotes>
     <tags>roslyn, analyzers, semantics, merge, github, csharp</tags>
     <developmentDependency>true</developmentDependency>
     <frameworkAssemblies>

--- a/SemDiff.Core/SemDiffAnalyzer.cs
+++ b/SemDiff.Core/SemDiffAnalyzer.cs
@@ -9,13 +9,19 @@ using System.Threading.Tasks;
 
 namespace SemDiff.Core
 {
+    /// <summary>
+    /// Diagnostic Analyzer that uses semantics to detects potential conflicts with GitHub pull requests
+    /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class SemDiffAnalyzer : DiagnosticAnalyzer
     {
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => Diagnostics.Supported;
         internal static DataStore Store { get; } = new DataStore();
 
-        //Called once per solution, to provide us an oportunity to assign callbacks
+        /// <summary>
+        /// Called once at session start to register actions in the analysis context.
+        /// </summary>
+        /// <param name="context">object that allows the assignment of callbacks</param>
         public override void Initialize(AnalysisContext context)
         {
 #if DEBUG

--- a/SemDiff.Core/SpanDetails.cs
+++ b/SemDiff.Core/SpanDetails.cs
@@ -8,13 +8,18 @@ namespace SemDiff.Core
     /// </summary>
     public class SpanDetails
     {
-        public TextSpan Span { get; set; }
-        public string Text => Tree?.GetText().ToString(Span);
-        public SyntaxNode Node => Tree?.GetRoot().FindNode(Span, true, false);
-        public SyntaxTree Tree { get; set; }
-
         private SpanDetails()
         {
+        }
+
+        public SyntaxNode Node => Tree?.GetRoot().FindNode(Span, true, false);
+        public TextSpan Span { get; set; }
+        public string Text => Tree?.GetText().ToString(Span);
+        public SyntaxTree Tree { get; set; }
+
+        public override string ToString()
+        {
+            return Text;
         }
 
         internal static SpanDetails Create(int start, int end, SyntaxTree tree)
@@ -29,11 +34,6 @@ namespace SemDiff.Core
                 Tree = tree,
                 Span = span
             };
-        }
-
-        public override string ToString()
-        {
-            return Text;
         }
     }
 }

--- a/SemDiff.Test/Diff3Tests.cs
+++ b/SemDiff.Test/Diff3Tests.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SemDiff.Core;

--- a/SemDiff.Test/FalseNegativeAnalysisTests.cs
+++ b/SemDiff.Test/FalseNegativeAnalysisTests.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.MSBuild;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SemDiff.Core;
@@ -71,26 +70,5 @@ namespace SemDiff.Test
             var res = Analysis.ForFalseNegative(CurlyBroccoli, model);
             Assert.IsTrue(res.Any());
         }
-
-        private static string consolLoggerText = @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Curly
-{
-    /// <summary>
-    /// Extend the logger class to log all logs to console in addition to the list
-    /// </summary>
-    public class ConsoleLogger : Logger
-    {
-        public override void Log(Log log)
-        {
-            Console.WriteLine(log.Message);
-            base.Log(log);
-        }
-    }
-}";
     }
 }

--- a/SemDiff.Test/LoggerTests.cs
+++ b/SemDiff.Test/LoggerTests.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SemDiff.Core;
-using System;
 
 namespace SemDiff.Test
 {

--- a/SemDiff.Test/Properties/AssemblyInfo.cs
+++ b/SemDiff.Test/Properties/AssemblyInfo.cs
@@ -1,8 +1,7 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("SemDiff.Test")]
@@ -14,8 +13,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
@@ -25,11 +24,11 @@ using System.Runtime.InteropServices;
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
-//      Minor Version 
+//      Minor Version
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Build and Revision Numbers 
+// You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]

--- a/SemDiff.Test/PullRequestListTests.cs
+++ b/SemDiff.Test/PullRequestListTests.cs
@@ -59,6 +59,7 @@ namespace SemDiff.Test
             }
             Assert.AreEqual("895d2ca038344aacfbcf3902e978de73a7a763fe", r.Head.Sha);
         }
+
         [TestMethod]
         public void EtagNotModified()
         {
@@ -83,6 +84,7 @@ namespace SemDiff.Test
             var roslynPRs = github.GetPullRequestsAsync().Result;
             Assert.IsTrue(roslynPRs.Count > 30);
         }
+
         [TestMethod]
         public void FilesPagination()
         {
@@ -98,6 +100,7 @@ namespace SemDiff.Test
                     Assert.AreEqual(40, pr.Files.Count);
             }
         }
+
         [TestMethod]
         public void GetFilesFromGitHub()
         {
@@ -148,10 +151,11 @@ namespace SemDiff.Test
             }
             Assert.AreEqual(fourWasFound, true);
         }
+
         [TestMethod]
         public void UpdateLocalSaved()
         {
-            github.GetPullRequestsAsync();
+            github.GetPullRequestsAsync().Wait();
             var path = github.RepoFolder.Replace('/', Path.DirectorySeparatorChar);
             path = Path.Combine(path, github.JsonFileName);
             new FileInfo(path).Directory.Create();
@@ -176,6 +180,7 @@ namespace SemDiff.Test
             Assert.IsNotNull(local.Base);
             Assert.IsNotNull(local.Files);
         }
+
         [TestMethod]
         public void RemoveUnusedLocalFiles()
         {
@@ -210,6 +215,7 @@ namespace SemDiff.Test
             path = Path.Combine(path, "0");
             Assert.IsFalse(Directory.Exists(path));
         }
+
         [TestMethod]
         public void LastSessionLocalFiles()
         {
@@ -218,6 +224,7 @@ namespace SemDiff.Test
             var newgithub = new GitHub(owner, repository);
             Assert.IsNotNull(newgithub.CurrentSaved);
         }
+
         [TestMethod]
         public void NoUnnecessaryDownloading()
         {

--- a/SemDiff.Test/RepoTests.cs
+++ b/SemDiff.Test/RepoTests.cs
@@ -1,8 +1,5 @@
-﻿using LibGit2Sharp;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using SemDiff.Core;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.IO;
 using System.Linq;
 
 namespace SemDiff.Test

--- a/SemDiff.Test/SemDiff.Test.csproj
+++ b/SemDiff.Test/SemDiff.Test.csproj
@@ -161,8 +161,6 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\packages\codecracker.CSharp.1.0.0-rc5\analyzers\dotnet\cs\CodeCracker.Common.dll" />
-    <Analyzer Include="..\packages\codecracker.CSharp.1.0.0-rc5\analyzers\dotnet\cs\CodeCracker.CSharp.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
   </ItemGroup>

--- a/SemDiff.Test/packages.config
+++ b/SemDiff.Test/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="codecracker.CSharp" version="1.0.0-rc5" targetFramework="net461" />
   <package id="LibGit2Sharp" version="0.21.0.176" targetFramework="net461" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net461" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net461" />


### PR DESCRIPTION
Non-Semantic Changes
 * Ran the code Formatter on all code
 * Improved comments and XML documentation.
 * Moved methods around with Code-Maid to a more normal 
 * Fix spelling errors in documentation

Very few semantic changes:
 * Changed access modifiers to more appropriate levels
 * Renamed methods where the name was different than its function
 * Removed code-cracker from Test suite because it was producing too many diagnostics messages there
 * Fix spelling errors in error strings