### PR TITLE
Verify pull request cache in case of corruption

### DIFF
--- a/SemDiff.Core/Repo.cs
+++ b/SemDiff.Core/Repo.cs
@@ -143,22 +143,27 @@ namespace SemDiff.Core
                 var json = File.ReadAllText(CachedLocalPullRequestListPath);
                 var list = JsonConvert.DeserializeObject<IEnumerable<PullRequest>>(json);
                 PullRequests.Clear();
-                //Restore Self-Referential Loops
                 foreach (var p in list)
                 {
+                    //Restore Self-Referential Loops
+                    p.ParentRepo = this;
+                    foreach (var r in p.Files)
+                    {
+                        r.ParentPullRequst = p;
+                    }
+
                     if (VerifyPullRequestCache(p))
                     {
-                        p.ParentRepo = this;
                         PullRequests.Add(p);
                         foreach (var r in p.Files)
                         {
-                            r.ParentPullRequst = p;
                             r.LoadFromCache();
                         }
                     }
                     else
                     {
-                        Directory.Delete(p.CacheDirectory, true);
+                        if (Directory.Exists(p.CacheDirectory))
+                            Directory.Delete(p.CacheDirectory, true);
                     }
                 }
 

--- a/SemDiff.Core/Repo.cs
+++ b/SemDiff.Core/Repo.cs
@@ -136,32 +136,54 @@ namespace SemDiff.Core
             Debug.Assert(this != null);
             try
             {
-                var path = CachedLocalPullRequestListPath;
-                if (File.Exists(path))
+                if (!Directory.Exists(CacheDirectory))
+                    return;
+                if (!File.Exists(CachedLocalPullRequestListPath))
+                    return;
+                var json = File.ReadAllText(CachedLocalPullRequestListPath);
+                var list = JsonConvert.DeserializeObject<IEnumerable<PullRequest>>(json);
+                PullRequests.Clear();
+                //Restore Self-Referential Loops
+                foreach (var p in list)
                 {
-                    var json = File.ReadAllText(path);
-                    var list = JsonConvert.DeserializeObject<IEnumerable<PullRequest>>(json);
-
-                    //Restore Self-Referential Loops
-                    foreach (var p in list)
+                    if (VerifyPullRequestCache(p))
                     {
                         p.ParentRepo = this;
+                        PullRequests.Add(p);
                         foreach (var r in p.Files)
                         {
                             r.ParentPullRequst = p;
                             r.LoadFromCache();
                         }
                     }
-
-                    PullRequests.Clear();
-                    PullRequests.AddRange(list);
+                    else
+                    {
+                        Directory.Delete(p.CacheDirectory, true);
+                    }
                 }
+
+                UpdateLocalSavedList(); //In case some were deleted, write the file back
             }
             catch (Exception ex)
             {
-                //Directory.Delete(CacheDirectory); This may be a good idea with a few more checks
                 Logger.Error($"{ex.GetType().Name}: Couldn't load {CachedLocalPullRequestListPath} because {ex.Message}");
             }
+        }
+
+        private static bool VerifyPullRequestCache(PullRequest p)
+        {
+            if (!Directory.Exists(p.CacheDirectory))
+                return false;
+
+            foreach (var f in p.Files)
+            {
+                if (!File.Exists(f.CachePathBase))
+                    return false;
+                if (!File.Exists(f.CachePathHead))
+                    return false;
+            }
+
+            return true;
         }
 
         /// <summary>
@@ -223,10 +245,8 @@ namespace SemDiff.Core
         /// </summary>
         public void UpdateLocalSavedList()
         {
-            var path = CacheDirectory.ToLocalPath();
-            path = Path.Combine(path, CachedLocalPullRequestListPath);
-            new FileInfo(path).Directory.Create();
-            File.WriteAllText(path, JsonConvert.SerializeObject(PullRequests, Formatting.Indented));
+            Directory.CreateDirectory(CacheDirectory);
+            File.WriteAllText(CachedLocalPullRequestListPath, JsonConvert.SerializeObject(PullRequests, Formatting.Indented));
         }
 
         /// <summary>

--- a/SemDiff.Test/PullRequestListTests.cs
+++ b/SemDiff.Test/PullRequestListTests.cs
@@ -179,9 +179,16 @@ namespace SemDiff.Test
         {
             var requests = github.GetPullRequestsAsync().Result;
             var zeroDir = Path.Combine(github.CacheDirectory.Replace('/', Path.DirectorySeparatorChar), "0");
-            Directory.CreateDirectory(zeroDir);
-            var prZero = requests.First().Clone();
+            var prZero = requests.OrderBy(p => p.Number).First().Clone();
             prZero.Number = 0;
+            prZero.ParentRepo = github;
+            foreach (var f in prZero.Files) //Add files to fool it!
+            {
+                f.ParentPullRequst = prZero;
+                new FileInfo(f.CachePathBase).Directory.Create();
+                File.WriteAllText(f.CachePathBase, "<BAD>");
+                File.WriteAllText(f.CachePathHead, "<BAD>");
+            }
             github.PullRequests.Add(prZero);
             var json = github.CachedLocalPullRequestListPath;
             File.WriteAllText(json, JsonConvert.SerializeObject(github.PullRequests));


### PR DESCRIPTION
Pull Requests that are missing files are dropped

This fixes a bug that I found that prevented semdiff from restarting after files became missing from the cache 